### PR TITLE
chore: add option to get tuner and sc from public github

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ To install the package, run in a new python 3.8+ environment:
    cd MELLODDY-Predictor
    ```
 
-2. Install the package and its requirements. You can remove `gitlab` if you already installed `melloddy_tuner` and `sparsechem`. You can remove `doc` if you don't want to build it.
+2. Install the package and its requirements. You can remove `github` if you already installed `melloddy_tuner` and `sparsechem`. You can remove `doc` if you don't want to build it.
 
    ```sh
-   pip install -e ".[gitlab,doc]"
+   pip install -e ".[github,doc]"
    ```
 
 3. (Optional) To be able to run the examples and the tests, download the [dummy files](https://zenodo.org/record/6807845/). You can download it using `make inputs`. Otherwise download the archive, extract it an place the `inputs` folder at the root of the project.

--- a/setup.py
+++ b/setup.py
@@ -38,14 +38,9 @@ setup(
         "pandas==1.*",
     ],
     extras_require={
-        "gitlab": [
-            "melloddy_tuner@git+ssh://git@gitlab.com/melloddy/wp1/data_prep.git@develop",
-            "sparsechem@git+ssh://git@gitlab.com/melloddy/wp2/sparsechem.git",
-            "protobuf==3.20.*",
-        ],
         "github": [
-            "melloddy_tuner@git+ssh://git@github.com/MELLODDY/MELLODDY-TUNER.git@master",
-            "sparsechem@git+ssh://git@github.com/MELLODDY/SparseChem.git@master",
+            "melloddy_tuner@git+https://git@github.com/MELLODDY/MELLODDY-TUNER.git@master",
+            "sparsechem@git+https://git@github.com/MELLODDY/SparseChem.git@master",
             "protobuf==3.20.*",
         ],
         "doc": [

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,11 @@ setup(
             "sparsechem@git+ssh://git@gitlab.com/melloddy/wp2/sparsechem.git",
             "protobuf==3.20.*",
         ],
+        "github": [
+            "melloddy_tuner@git+ssh://git@github.com/MELLODDY/MELLODDY-TUNER.git@master",
+            "sparsechem@git+ssh://git@github.com/MELLODDY/SparseChem.git@master",
+            "protobuf==3.20.*",
+        ],
         "doc": [
             "pdoc3==0.10.*",
         ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Addition of the option to install tuner and sparsechem from the public github. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This should address issue #10, which was made possible after the recent update of tuner on GitHub. 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
`make test `passes

## Ping Reviewers
@melloddy/predictor-users

## Please check if the PR fulfills these requirements

- [ ] If necessary, the [changelog](https://github.com/melloddy/MELLODDY_Predictor/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
