### PR TITLE
feat: output trunk embeddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - feat: warn if failing SMILES (#3)
 - feat: use inverse_normalization for reg and hyb models (#7)
+- feat: Output Trunk Embeddings
+  added `return_trunk_embeddings` arg to `predict` function
 
 ## Fixed
 

--- a/melloddy_predictor/model.py
+++ b/melloddy_predictor/model.py
@@ -242,7 +242,8 @@ class Model:
                 (see `torch.utils.data.DataLoader` for more details).
             num_workers: How many subprocess we should use for data loading
                 (see `torch.utils.data.DataLoader` for more details).
-            return_trunk_embeddings: If True, return trunk embeddings (before non-linearity, e.g relu,tanh) instead of Yhat
+            return_trunk_embeddings: If True, return trunk embeddings (before non-linearity, e.g relu,tanh) instead of
+                Yhat
 
         Returns:
             if return_trunk_embeddings is set to True:
@@ -250,11 +251,11 @@ class Model:
             else:
                 Tuple[pd.DataFrame, pd.DataFrame]: `cls_pred` and `reg_pred`
                 - `cls_pred`: the prediction dataframe for classification tasks: the columns are the tasks
-                    (`input_assay_id`_`threshold` from the `classification metadata` file) and the rows are the compounds
-                    ids (`input_compound_id` from the `smiles` file).
+                    (`input_assay_id`_`threshold` from the `classification metadata` file) and the rows are the
+                    compounds ids (`input_compound_id` from the `smiles` file).
                 - `reg_pred`: the prediction dataframe for regression tasks: the columns are the tasks (`input_assay_id`
-                    from the `regression metadata` file) and the rows are the compounds ids (`input_compound_id` from the
-                    `smiles` file).
+                    from the `regression metadata` file) and the rows are the compounds ids (`input_compound_id` from
+                    the `smiles` file).
         """
 
         data = sparsechem.fold_transform_inputs(

--- a/tests/test_prediction_system.py
+++ b/tests/test_prediction_system.py
@@ -190,3 +190,30 @@ def test_load_on_demand():
     cls_pred, _ = model.predict(prepared_data)
     assert cls_pred.shape == (df.shape[0], model._class_output_size)
     assert model._model
+
+
+@pytest.mark.parametrize(
+    ["model", "trunk_size"],
+    [
+        ("example_cls_model", 600),
+        ("example_clsaux_model", 600),
+        ("example_reg_model", 300),
+        ("example_hyb_model", 300),
+    ],
+)
+@pytest.mark.slow
+def test_trunk_embeddings(model, trunk_size):
+    df: pd.DataFrame = melloddy_tuner.utils.helper.read_input_file(str(SMILES_PATH))
+
+    prepared_data = PreparedData(
+        encryption_key=ENCRYPTION_KEY,
+        preparation_parameters=PREPARATION_PARAMETER,
+        smiles=df,
+        num_cpu=NUM_CPU,
+    )
+
+    model = Model(MODELS_PATH / model)
+
+    trunk_embeddings = model.predict(prepared_data, return_trunk_embeddings=True)
+
+    assert trunk_embeddings.shape == (df.shape[0], trunk_size)


### PR DESCRIPTION

Signed-off-by: Fabien Gelus <fabien.gelus@owkin.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
added `return_trunk_embeddings` arg to `predict` function
If True, return trunk embeddings (before non-linearity, e.g relu,tanh) instead of Yhat

https://github.com/melloddy/MELLODDY-Predictor/pull/15
and 
https://github.com/melloddy/SparseChem/pull/6
would need to be merged prior merging this PR

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/melloddy/MELLODDY-Predictor/issues/16 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

To test: pip install sparsechem@git+https://git@github.com/MELLODDY/SparseChem.git@4-predicting-last_hidden




## Ping Reviewers
@melloddy/predictor-users

## Please check if the PR fulfills these requirements

- [ ] If necessary, the [changelog](https://github.com/melloddy/MELLODDY_Predictor/blob/main/CHANGELOG.md) has been updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

